### PR TITLE
Add fix all for NUnit

### DIFF
--- a/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
+++ b/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
@@ -16,6 +16,44 @@ public sealed class NUnitToFluentAssertionsAnalyzerUnitTests
             .AddFluentAssertionsApi();
     }
 
+    [Fact]
+    public async Task FixDocumentWithMultipleDiagnostics()
+    {
+        var test = @"
+using NUnit.Framework;
+
+class Test
+{
+    public void MyTest()
+    {
+        var value = false;
+        [|Assert.True(value)|];
+        [|Assert.False(value)|];
+    }
+}
+";
+        var fix = @"
+using FluentAssertions;
+using NUnit.Framework;
+
+class Test
+{
+    public void MyTest()
+    {
+        var value = false;
+        value.Should().BeTrue();
+        value.Should().BeFalse();
+    }
+}
+";
+
+        await CreateProjectBuilder()
+                .WithSourceCode(test)
+                .ShouldFixCodeWith(fix)
+                .ShouldBatchFixCodeWith(fix)
+                .ValidateAsync();
+    }
+
     private static Task Assert(string sourceCode, string fix)
     {
         return CreateProjectBuilder()

--- a/Meziantou.FluentAssertionsAnalyzers/Internals/DocumentBasedFixAllProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/Internals/DocumentBasedFixAllProvider.cs
@@ -1,0 +1,113 @@
+﻿// File initially copied from
+//  https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/4d9b3e3bb785a55f73b3029a843f0c0b73cc9ea7/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/DocumentBasedFixAllProvider.cs
+// Original copyright statement:
+//  Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+//  Licensed under the MIT License. See LICENSE in the project root for license information.
+
+# nullable enable
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.FluentAssertionsAnalyzers.Internals;
+
+/// <summary>
+/// Provides a base class to write a <see cref="FixAllProvider"/> that fixes documents independently.
+/// </summary>
+internal abstract class DocumentBasedFixAllProvider : FixAllProvider
+{
+    protected abstract string CodeActionTitle { get; }
+
+    public override Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
+    {
+        return Task.FromResult(fixAllContext.Scope switch
+        {
+            FixAllScope.Document => CodeAction.Create(
+                                        CodeActionTitle,
+                                        cancellationToken => GetDocumentFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                                        nameof(DocumentBasedFixAllProvider)),
+            FixAllScope.Project => CodeAction.Create(
+                                        CodeActionTitle,
+                                        cancellationToken => GetProjectFixesAsync(fixAllContext.WithCancellationToken(cancellationToken), fixAllContext.Project),
+                                        nameof(DocumentBasedFixAllProvider)),
+            FixAllScope.Solution => CodeAction.Create(
+                                        CodeActionTitle,
+                                        cancellationToken => GetSolutionFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                                        nameof(DocumentBasedFixAllProvider)),
+            _ => null,
+        });
+    }
+
+    /// <summary>
+    /// Fixes all occurrences of a diagnostic in a specific document.
+    /// </summary>
+    /// <param name="fixAllContext">The context for the Fix All operation.</param>
+    /// <param name="document">The document to fix.</param>
+    /// <param name="diagnostics">The diagnostics to fix in the document.</param>
+    /// <returns>
+    /// <para>The new <see cref="SyntaxNode"/> representing the root of the fixed document.</para>
+    /// <para>-or-</para>
+    /// <para><see langword="null"/>, if no changes were made to the document.</para>
+    /// </returns>
+    protected abstract Task<SyntaxNode?> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics);
+
+    private async Task<Document> GetDocumentFixesAsync(FixAllContext fixAllContext)
+    {
+        var document = fixAllContext.Document!;
+        var documentDiagnosticsToFix = await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
+        if (!documentDiagnosticsToFix.TryGetValue(document, out var diagnostics))
+        {
+            return document;
+        }
+
+        var newRoot = await FixAllInDocumentAsync(fixAllContext, document, diagnostics).ConfigureAwait(false);
+        if (newRoot == null)
+        {
+            return document;
+        }
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private async Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext, ImmutableArray<Document> documents)
+    {
+        var documentDiagnosticsToFix = await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
+
+        var solution = fixAllContext.Solution;
+        var newDocuments = new List<Task<SyntaxNode?>>(documents.Length);
+        foreach (var document in documents)
+        {
+            if (!documentDiagnosticsToFix.TryGetValue(document, out var diagnostics))
+            {
+                newDocuments.Add(document.GetSyntaxRootAsync(fixAllContext.CancellationToken));
+                continue;
+            }
+
+            newDocuments.Add(FixAllInDocumentAsync(fixAllContext, document, diagnostics));
+        }
+
+        for (var i = 0; i < documents.Length; i++)
+        {
+            var newDocumentRoot = await newDocuments[i].ConfigureAwait(false);
+            if (newDocumentRoot == null)
+                continue;
+
+            solution = solution.WithDocumentSyntaxRoot(documents[i].Id, newDocumentRoot);
+        }
+
+        return solution;
+    }
+
+    private Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext, Project project)
+    {
+        return GetSolutionFixesAsync(fixAllContext, project.Documents.ToImmutableArray());
+    }
+
+    private Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext)
+    {
+        var documents = fixAllContext.Solution.Projects.SelectMany(i => i.Documents).ToImmutableArray();
+        return GetSolutionFixesAsync(fixAllContext, documents);
+    }
+}

--- a/Meziantou.FluentAssertionsAnalyzers/Internals/FixAllContextHelper.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/Internals/FixAllContextHelper.cs
@@ -1,0 +1,142 @@
+﻿// File initially copied from
+//  https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/4d9b3e3bb785a55f73b3029a843f0c0b73cc9ea7/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
+// Original copyright statement:
+//  Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+//  Licensed under the MIT License. See LICENSE in the project root for license information.
+
+# nullable enable
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.FluentAssertionsAnalyzers.Internals;
+
+internal static class FixAllContextHelper
+{
+    public static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(FixAllContext fixAllContext)
+    {
+        var allDiagnostics = ImmutableArray<Diagnostic>.Empty;
+        var projectsToFix = ImmutableArray<Project>.Empty;
+
+        var document = fixAllContext.Document;
+        var project = fixAllContext.Project;
+
+        switch (fixAllContext.Scope)
+        {
+            case FixAllScope.Document:
+                if (document != null)
+                {
+                    var documentDiagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                    return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty.SetItem(document, documentDiagnostics);
+                }
+
+                break;
+
+            case FixAllScope.Project:
+                projectsToFix = ImmutableArray.Create(project);
+                allDiagnostics = await GetAllDiagnosticsAsync(fixAllContext, project).ConfigureAwait(false);
+                break;
+
+            case FixAllScope.Solution:
+                projectsToFix = project.Solution.Projects
+                    .Where(p => p.Language == project.Language)
+                    .ToImmutableArray();
+
+                var diagnostics = new ConcurrentDictionary<ProjectId, ImmutableArray<Diagnostic>>();
+                var tasks = new Task[projectsToFix.Length];
+                for (var i = 0; i < projectsToFix.Length; i++)
+                {
+                    fixAllContext.CancellationToken.ThrowIfCancellationRequested();
+                    var projectToFix = projectsToFix[i];
+                    tasks[i] = Task.Run(
+                        async () =>
+                        {
+                            var projectDiagnostics = await GetAllDiagnosticsAsync(fixAllContext, projectToFix).ConfigureAwait(false);
+                            diagnostics.TryAdd(projectToFix.Id, projectDiagnostics);
+                        }, fixAllContext.CancellationToken);
+                }
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+                allDiagnostics = allDiagnostics.AddRange(diagnostics.SelectMany(i => i.Value.Where(x => fixAllContext.DiagnosticIds.Contains(x.Id))));
+                break;
+        }
+
+        if (allDiagnostics.IsEmpty)
+        {
+            return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty;
+        }
+
+        return await GetDocumentDiagnosticsToFixAsync(allDiagnostics, projectsToFix, fixAllContext.CancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets all <see cref="Diagnostic"/> instances within a specific <see cref="Project"/> which are relevant to a
+    /// <see cref="FixAllContext"/>.
+    /// </summary>
+    /// <param name="fixAllContext">The context for the Fix All operation.</param>
+    /// <param name="project">The project.</param>
+    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. When the task completes
+    /// successfully, the <see cref="Task{TResult}.Result"/> will contain the requested diagnostics.</returns>
+    private static async Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsAsync(FixAllContext fixAllContext, Project project)
+    {
+        return await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+    }
+
+    private static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(
+        ImmutableArray<Diagnostic> diagnostics,
+        ImmutableArray<Project> projects,
+        CancellationToken cancellationToken)
+    {
+        var treeToDocumentMap = await GetTreeToDocumentMapAsync(projects, cancellationToken).ConfigureAwait(false);
+
+        var builder = ImmutableDictionary.CreateBuilder<Document, ImmutableArray<Diagnostic>>();
+        foreach (var documentAndDiagnostics in diagnostics.GroupBy(d => GetReportedDocument(d, treeToDocumentMap)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var document = documentAndDiagnostics.Key;
+            if (document != null)
+            {
+                var diagnosticsForDocument = documentAndDiagnostics.ToImmutableArray();
+                builder.Add(document, diagnosticsForDocument);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static async Task<ImmutableDictionary<SyntaxTree, Document>> GetTreeToDocumentMapAsync(ImmutableArray<Project> projects, CancellationToken cancellationToken)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<SyntaxTree, Document>();
+        foreach (var project in projects)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (var document in project.Documents)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                if (tree != null)
+                {
+                    builder.Add(tree, document);
+                }
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static Document? GetReportedDocument(Diagnostic diagnostic, ImmutableDictionary<SyntaxTree, Document> treeToDocumentsMap)
+    {
+        var tree = diagnostic.Location.SourceTree;
+        if (tree != null)
+        {
+            if (treeToDocumentsMap.TryGetValue(tree, out var document))
+            {
+                return document;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Add fix all for NUnit.

Based on https://github.com/meziantou/Meziantou.Analyzer.

Fixes #12.

## Testing

I tested it by registering a local source (`dotnet nuget add source`) and creating a NuGet package (bumped the version and run `dotnet pack`), but it doesn't work. :(
The good news is, that a local version of a package is being used for sure: 
![image](https://user-images.githubusercontent.com/26791344/200179598-02afea01-0fa3-4154-ab07-eda363b012b3.png)
Any hints much appreciated 🤷 