### PR TITLE
Support `dynamic`

### DIFF
--- a/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
+++ b/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
@@ -77,7 +77,7 @@ class Test
     public void MyTest()
     {
         dynamic val = new object();
-        val.Should().NotBeNull();
+        ((object)val).Should().NotBeNull();
     }
 }
 """);
@@ -108,7 +108,7 @@ class Test
     public void MyTest()
     {
         dynamic val = new object();
-        val.Prop.Should().NotBeNull();
+        ((object)val.Prop).Should().NotBeNull();
     }
 }
 """);

--- a/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
+++ b/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
@@ -51,7 +51,69 @@ class Test
 }
 """);
     }
-    
+
+    [Fact]
+    public Task Assert_Dynamic()
+    {
+        return Assert(
+"""
+using NUnit.Framework;
+
+class Test
+{
+    public void MyTest()
+    {
+        dynamic val = new object();
+        [|Assert.That(val, Is.Not.Null)|];
+    }
+}
+""",
+"""
+using FluentAssertions;
+using NUnit.Framework;
+
+class Test
+{
+    public void MyTest()
+    {
+        dynamic val = new object();
+        val.Should().NotBeNull();
+    }
+}
+""");
+    }
+
+    [Fact]
+    public Task Assert_DynamicProp()
+    {
+        return Assert(
+            """
+using NUnit.Framework;
+
+class Test
+{
+    public void MyTest()
+    {
+        dynamic val = new object();
+        [|Assert.That(val.Prop, Is.Not.Null)|];
+    }
+}
+""",
+            """
+using FluentAssertions;
+using NUnit.Framework;
+
+class Test
+{
+    public void MyTest()
+    {
+        dynamic val = new object();
+        val.Prop.Should().NotBeNull();
+    }
+}
+""");
+    }
+
     [Fact]
     public Task Rethrow()
     {

--- a/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
@@ -154,7 +154,8 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
             return document;
 
         var arguments = invocationExpression.ArgumentList.Arguments;
-        var method = (IMethodSymbol)editor.SemanticModel.GetSymbolInfo(invocationExpression, cancellationToken).Symbol;
+        var symbolInfo = editor.SemanticModel.GetSymbolInfo(invocationExpression, cancellationToken);
+        var method = (IMethodSymbol)(symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault());
         if (method == null)
             return document;
 

--- a/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Meziantou.FluentAssertionsAnalyzers.NunitAssertAnalyzerCodeFixProvider.Rewriter;
 
 namespace Meziantou.FluentAssertionsAnalyzers;
 
@@ -808,39 +809,42 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
         return list;
     }
 
-    private static SyntaxNode RewriteUsingShould(ArgumentSyntax subject, string methodName, IEnumerable<ArgumentSyntax> arguments)
+    internal static class Rewriter
     {
-        return RewriteUsingShould(subject.Expression, methodName, genericParameterType: null, arguments);
-    }
+        public static SyntaxNode RewriteUsingShould(ArgumentSyntax subject, string methodName, IEnumerable<ArgumentSyntax> arguments)
+        {
+            return RewriteUsingShould(subject.Expression, methodName, genericParameterType: null, arguments);
+        }
 
-    private static SyntaxNode RewriteUsingShould(ExpressionSyntax subject, string methodName, IEnumerable<ArgumentSyntax> arguments)
-    {
-        return RewriteUsingShould(subject, methodName, genericParameterType: null, arguments);
-    }
+        public static SyntaxNode RewriteUsingShould(ExpressionSyntax subject, string methodName, IEnumerable<ArgumentSyntax> arguments)
+        {
+            return RewriteUsingShould(subject, methodName, genericParameterType: null, arguments);
+        }
 
-    private static SyntaxNode RewriteUsingShould(ArgumentSyntax subject, string methodName, TypeSyntax genericParameterType, IEnumerable<ArgumentSyntax> arguments)
-    {
-        return RewriteUsingShould(subject.Expression, methodName, genericParameterType, arguments);
-    }
+        public static SyntaxNode RewriteUsingShould(ArgumentSyntax subject, string methodName, TypeSyntax genericParameterType, IEnumerable<ArgumentSyntax> arguments)
+        {
+            return RewriteUsingShould(subject.Expression, methodName, genericParameterType, arguments);
+        }
 
-    private static SyntaxNode RewriteUsingShould(ExpressionSyntax subject, string methodName, TypeSyntax genericParameterType, IEnumerable<ArgumentSyntax> arguments)
-    {
-        var should = InvokeShould(subject);
-        should = InvocationExpression(MemberAccessExpression(should, methodName, genericParameterType));
-        should = should.AddArgumentListArguments(arguments.Select(arg => Argument(arg.Expression)).ToArray());
-        return should;
-    }
+        public static SyntaxNode RewriteUsingShould(ExpressionSyntax subject, string methodName, TypeSyntax genericParameterType, IEnumerable<ArgumentSyntax> arguments)
+        {
+            var should = InvokeShould(subject);
+            should = InvocationExpression(MemberAccessExpression(should, methodName, genericParameterType));
+            should = should.AddArgumentListArguments(arguments.Select(arg => Argument(arg.Expression)).ToArray());
+            return should;
+        }
 
-    private static SyntaxNode RewriteTrueOrFalse(SeparatedSyntaxList<ArgumentSyntax> originalArguments, string methodName)
-    {
-        return RewriteUsingShould(originalArguments[0], "Be" + methodName, originalArguments.Skip(1).ToArray());
-    }
+        public static SyntaxNode RewriteTrueOrFalse(SeparatedSyntaxList<ArgumentSyntax> originalArguments, string methodName)
+        {
+            return RewriteUsingShould(originalArguments[0], "Be" + methodName, originalArguments.Skip(1).ToArray());
+        }
 
-    private static InvocationExpressionSyntax InvokeShould(ExpressionSyntax expression)
-    {
-        return InvocationExpression(
-                MemberAccessExpression(Parenthesize(expression), "Should"))
-            .WithAdditionalAnnotations(Simplifier.Annotation);
+        private static InvocationExpressionSyntax InvokeShould(ExpressionSyntax expression)
+        {
+            return InvocationExpression(
+                    MemberAccessExpression(Parenthesize(expression), "Should"))
+                .WithAdditionalAnnotations(Simplifier.Annotation);
+        }
     }
 
     private static ExpressionSyntax InvokeFluentActionsInvoking(Compilation compilation, SyntaxGenerator generator, ExpressionSyntax expression)

--- a/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using static Meziantou.FluentAssertionsAnalyzers.NunitAssertAnalyzerCodeFixProvider.Rewriter;
 
 namespace Meziantou.FluentAssertionsAnalyzers;
 
@@ -169,6 +168,8 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
         var typeSymbol = compilation.GetTypeByMetadataName("System.Type");
         var resolveConstraintSymbol = compilation.GetTypeByMetadataName("NUnit.Framework.Constraints.IResolveConstraint");
 
+        var rewrite = new Rewriter();
+
         SyntaxNode result = null;
         var addImports = true;
         if (method.ContainingType.Equals(compilation.GetTypeByMetadataName("NUnit.Framework.Assert"), SymbolEqualityComparer.Default))
@@ -177,106 +178,106 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
             {
                 if (method.Parameters[0].Type.SpecialType == SpecialType.System_Double)
                 {
-                    result = RewriteUsingShould(arguments[1], "BeApproximately", ArgumentList(arguments[0], arguments.Skip(2)));
+                    result = rewrite.UsingShould(arguments[1], "BeApproximately", ArgumentList(arguments[0], arguments.Skip(2)));
                 }
                 else
                 {
-                    result = RewriteUsingShould(arguments[1], "Be", ArgumentList(arguments[0], arguments.Skip(2)));
+                    result = rewrite.UsingShould(arguments[1], "Be", ArgumentList(arguments[0], arguments.Skip(2)));
                 }
             }
             else if (methodName is "AreNotEqual")
             {
-                result = RewriteUsingShould(arguments[1], "NotBe", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotBe", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "AreSame")
             {
-                result = RewriteUsingShould(arguments[1], "BeSameAs", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "BeSameAs", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "AreNotSame")
             {
-                result = RewriteUsingShould(arguments[1], "NotBeSameAs", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotBeSameAs", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "IsEmpty" && method.Parameters[0].Type.SpecialType == SpecialType.System_String)
             {
-                result = RewriteUsingShould(arguments[0], "BeEmpty", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "BeEmpty", arguments.Skip(1));
             }
             else if (methodName is "IsEmpty")
             {
-                result = RewriteUsingShould(arguments[0], "BeEmpty", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "BeEmpty", arguments.Skip(1));
             }
             else if (methodName is "IsNotEmpty" && method.Parameters[0].Type.SpecialType == SpecialType.System_String)
             {
-                result = RewriteUsingShould(arguments[0], "NotBeEmpty", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "NotBeEmpty", arguments.Skip(1));
             }
             else if (methodName is "IsNotEmpty")
             {
-                result = RewriteUsingShould(arguments[0], "NotBeEmpty", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "NotBeEmpty", arguments.Skip(1));
             }
             else if (methodName is "IsInstanceOf" && method.TypeArguments.Length == 0)
             {
-                result = RewriteUsingShould(arguments[1], "BeOfType", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "BeOfType", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "IsInstanceOf" && method.TypeArguments.Length == 1)
             {
                 var genericType = (TypeSyntax)generator.TypeExpression(method.TypeArguments[0]);
-                result = RewriteUsingShould(arguments[0], "BeOfType", genericType, arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "BeOfType", genericType, arguments.Skip(1));
             }
             else if (methodName is "IsNotInstanceOf" && method.TypeArguments.Length == 0)
             {
-                result = RewriteUsingShould(arguments[1], "NotBeOfType", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotBeOfType", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "IsNotInstanceOf" && method.TypeArguments.Length == 1)
             {
                 var genericType = (TypeSyntax)generator.TypeExpression(method.TypeArguments[0]);
-                result = RewriteUsingShould(arguments[0], "NotBeOfType", genericType, arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "NotBeOfType", genericType, arguments.Skip(1));
             }
             else if (methodName is "IsNaN")
             {
-                result = RewriteUsingShould(arguments[0], "Be", ArgumentList(MemberAccessExpression((ExpressionSyntax)generator.TypeExpression(SpecialType.System_Double), "NaN"), arguments.Skip(1)));
+                result = rewrite.UsingShould(arguments[0], "Be", ArgumentList(MemberAccessExpression((ExpressionSyntax)generator.TypeExpression(SpecialType.System_Double), "NaN"), arguments.Skip(1)));
             }
             else if (methodName is "False" or "IsFalse")
             {
-                result = RewriteTrueOrFalse(arguments, "False");
+                result = rewrite.TrueOrFalse(arguments, "False");
             }
             else if (methodName is "Greater")
             {
-                result = RewriteUsingShould(arguments[1], "BeGreaterThan", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "BeGreaterThan", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "GreaterOrEqual")
             {
-                result = RewriteUsingShould(arguments[1], "BeGreaterThanOrEqualTo", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "BeGreaterThanOrEqualTo", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "Less")
             {
-                result = RewriteUsingShould(arguments[1], "BeLessThan", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "BeLessThan", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "LessOrEqual")
             {
-                result = RewriteUsingShould(arguments[1], "BeLessThanOrEqualTo", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "BeLessThanOrEqualTo", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "Negative")
             {
-                result = RewriteUsingShould(arguments[0], "BeNegative", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "BeNegative", arguments.Skip(1));
             }
             else if (methodName is "Null" or "IsNull")
             {
-                result = RewriteUsingShould(arguments[0], "BeNull", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "BeNull", arguments.Skip(1));
             }
             else if (methodName is "NotNull" or "IsNotNull")
             {
-                result = RewriteUsingShould(arguments[0], "NotBeNull", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "NotBeNull", arguments.Skip(1));
             }
             else if (methodName is "NotZero")
             {
-                result = RewriteUsingShould(arguments[0], "NotBe", ArgumentList(NumericLiteral(0), arguments.Skip(1)));
+                result = rewrite.UsingShould(arguments[0], "NotBe", ArgumentList(NumericLiteral(0), arguments.Skip(1)));
             }
             else if (methodName is "Positive")
             {
-                result = RewriteUsingShould(arguments[0], "BePositive", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "BePositive", arguments.Skip(1));
             }
             else if (methodName is "True" or "IsTrue")
             {
-                result = RewriteTrueOrFalse(arguments, "True");
+                result = rewrite.TrueOrFalse(arguments, "True");
             }
             else if (methodName is "Pass" && arguments.Count == 0)
             {
@@ -290,19 +291,19 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
             }
             else if (methodName is "Zero")
             {
-                result = RewriteUsingShould(arguments[0], "Be", ArgumentList(NumericLiteral(0), arguments.Skip(1)));
+                result = rewrite.UsingShould(arguments[0], "Be", ArgumentList(NumericLiteral(0), arguments.Skip(1)));
             }
             else if (methodName is "Catch" && method.TypeArguments.Length == 1)
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(method.TypeArguments[0]);
-                result = RewriteUsingShould(action, "Throw", exception, arguments.Skip(1));
+                result = rewrite.UsingShould(action, "Throw", exception, arguments.Skip(1));
             }
             else if (methodName is "Catch" && method.TypeArguments.Length == 0 && !method.Parameters[0].Type.Equals(typeSymbol, SymbolEqualityComparer.Default))
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(exceptionSymbol);
-                result = RewriteUsingShould(action, "Throw", exception, arguments.Skip(1));
+                result = rewrite.UsingShould(action, "Throw", exception, arguments.Skip(1));
             }
             else if (methodName is "Catch" && method.TypeArguments.Length == 0 && method.Parameters[0].Type.Equals(typeSymbol, SymbolEqualityComparer.Default))
             {
@@ -312,19 +313,19 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
 
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[1].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(exceptionType);
-                result = RewriteUsingShould(action, "Throw", exception, arguments.Skip(2));
+                result = rewrite.UsingShould(action, "Throw", exception, arguments.Skip(2));
             }
             else if (methodName is "CatchAsync" && method.TypeArguments.Length == 1)
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(method.TypeArguments[0]);
-                result = RewriteUsingShould(action, "ThrowAsync", exception, arguments.Skip(1));
+                result = rewrite.UsingShould(action, "ThrowAsync", exception, arguments.Skip(1));
             }
             else if (methodName is "CatchAsync" && method.TypeArguments.Length == 0 && !method.Parameters[0].Type.Equals(typeSymbol, SymbolEqualityComparer.Default))
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(exceptionSymbol);
-                result = RewriteUsingShould(action, "ThrowAsync", exception, arguments.Skip(1));
+                result = rewrite.UsingShould(action, "ThrowAsync", exception, arguments.Skip(1));
             }
             else if (methodName is "CatchAsync" && method.TypeArguments.Length == 0 && method.Parameters[0].Type.Equals(typeSymbol, SymbolEqualityComparer.Default))
             {
@@ -334,19 +335,19 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
 
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[1].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(exceptionType);
-                result = RewriteUsingShould(action, "ThrowAsync", exception, arguments.Skip(2));
+                result = rewrite.UsingShould(action, "ThrowAsync", exception, arguments.Skip(2));
             }
             else if (methodName is "Throws" && method.TypeArguments.Length == 1)
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(method.TypeArguments[0]);
-                result = RewriteUsingShould(action, "ThrowExactly", exception, arguments.Skip(1));
+                result = rewrite.UsingShould(action, "ThrowExactly", exception, arguments.Skip(1));
             }
             else if (methodName is "Throws" && method.TypeArguments.Length == 0 && !method.Parameters[0].Type.Equals(typeSymbol, SymbolEqualityComparer.Default))
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(exceptionSymbol);
-                result = RewriteUsingShould(action, "ThrowExactly", exception, arguments.Skip(1));
+                result = rewrite.UsingShould(action, "ThrowExactly", exception, arguments.Skip(1));
             }
             else if (methodName is "Throws" && method.TypeArguments.Length == 0 && method.Parameters[0].Type.Equals(typeSymbol, SymbolEqualityComparer.Default))
             {
@@ -356,19 +357,19 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
 
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[1].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(exceptionType);
-                result = RewriteUsingShould(action, "ThrowExactly", exception, arguments.Skip(2));
+                result = rewrite.UsingShould(action, "ThrowExactly", exception, arguments.Skip(2));
             }
             else if (methodName is "ThrowsAsync" && method.TypeArguments.Length == 1)
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(method.TypeArguments[0]);
-                result = RewriteUsingShould(action, "ThrowExactlyAsync", exception, arguments.Skip(1));
+                result = rewrite.UsingShould(action, "ThrowExactlyAsync", exception, arguments.Skip(1));
             }
             else if (methodName is "ThrowsAsync" && method.TypeArguments.Length == 0 && !method.Parameters[0].Type.Equals(typeSymbol, SymbolEqualityComparer.Default))
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(exceptionSymbol);
-                result = RewriteUsingShould(action, "ThrowExactlyAsync", exception, arguments.Skip(1));
+                result = rewrite.UsingShould(action, "ThrowExactlyAsync", exception, arguments.Skip(1));
             }
             else if (methodName is "ThrowsAsync" && method.TypeArguments.Length == 0 && method.Parameters[0].Type.Equals(typeSymbol, SymbolEqualityComparer.Default))
             {
@@ -378,23 +379,23 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
 
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[1].Expression);
                 var exception = (TypeSyntax)generator.TypeExpression(exceptionType);
-                result = RewriteUsingShould(action, "ThrowExactlyAsync", exception, arguments.Skip(2));
+                result = rewrite.UsingShould(action, "ThrowExactlyAsync", exception, arguments.Skip(2));
             }
             else if (methodName is "DoesNotThrow")
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
-                result = RewriteUsingShould(action, "NotThrow", arguments.Skip(1));
+                result = rewrite.UsingShould(action, "NotThrow", arguments.Skip(1));
             }
             else if (methodName is "DoesNotThrowAsync")
             {
                 var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
-                result = RewriteUsingShould(action, "NotThrowAsync", arguments.Skip(1));
+                result = rewrite.UsingShould(action, "NotThrowAsync", arguments.Skip(1));
             }
             else if (methodName is "That")
             {
                 if (method.Parameters.Length == 1 || (method.Parameters.Length >= 2 && method.Parameters[1].Type.Equals(stringSymbol, SymbolEqualityComparer.Default)))
                 {
-                    result = RewriteUsingShould(arguments[0], "BeTrue", arguments.Skip(1));
+                    result = rewrite.UsingShould(arguments[0], "BeTrue", arguments.Skip(1));
                 }
                 else if (method.Parameters.Length >= 2 && method.Parameters[1].Type.Equals(resolveConstraintSymbol, SymbolEqualityComparer.Default))
                 {
@@ -412,132 +413,132 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
                     {
                         if (method.Parameters[0].Type.SpecialType == SpecialType.System_Boolean && Is(isSymbol, "True"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeTrue", Array.Empty<ArgumentSyntax>());
+                            result = rewrite.UsingShould(arguments[0], "BeTrue", Array.Empty<ArgumentSyntax>());
                         }
                         else if (method.Parameters[0].Type.SpecialType == SpecialType.System_Boolean && Is(isSymbol, "False"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeFalse", Array.Empty<ArgumentSyntax>());
+                            result = rewrite.UsingShould(arguments[0], "BeFalse", Array.Empty<ArgumentSyntax>());
                         }
                         else if (method.Parameters[0].Type.SpecialType == SpecialType.System_Boolean && Is(isSymbol, "Not", "True"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeFalse", Array.Empty<ArgumentSyntax>());
+                            result = rewrite.UsingShould(arguments[0], "BeFalse", Array.Empty<ArgumentSyntax>());
                         }
                         else if (method.Parameters[0].Type.SpecialType == SpecialType.System_Boolean && Is(isSymbol, "Not", "False"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeTrue", Array.Empty<ArgumentSyntax>());
+                            result = rewrite.UsingShould(arguments[0], "BeTrue", Array.Empty<ArgumentSyntax>());
                         }
                         else if (method.Parameters[0].Type.Equals(nullableBooleanSymbol, SymbolEqualityComparer.Default) && Is(isSymbol, "True"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeTrue", Array.Empty<ArgumentSyntax>());
+                            result = rewrite.UsingShould(arguments[0], "BeTrue", Array.Empty<ArgumentSyntax>());
                         }
                         else if (method.Parameters[0].Type.Equals(nullableBooleanSymbol, SymbolEqualityComparer.Default) && Is(isSymbol, "False"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeFalse", Array.Empty<ArgumentSyntax>());
+                            result = rewrite.UsingShould(arguments[0], "BeFalse", Array.Empty<ArgumentSyntax>());
                         }
                         else if (method.Parameters[0].Type.Equals(nullableBooleanSymbol, SymbolEqualityComparer.Default) && Is(isSymbol, "Not", "True"))
                         {
-                            result = RewriteUsingShould(arguments[0], "NotBeTrue", Array.Empty<ArgumentSyntax>());
+                            result = rewrite.UsingShould(arguments[0], "NotBeTrue", Array.Empty<ArgumentSyntax>());
                         }
                         else if (method.Parameters[0].Type.Equals(nullableBooleanSymbol, SymbolEqualityComparer.Default) && Is(isSymbol, "Not", "False"))
                         {
-                            result = RewriteUsingShould(arguments[0], "NotBeFalse", Array.Empty<ArgumentSyntax>());
+                            result = rewrite.UsingShould(arguments[0], "NotBeFalse", Array.Empty<ArgumentSyntax>());
                         }
                         else if (Is(isSymbol, "Empty"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeEmpty", arguments.Skip(2));
+                            result = rewrite.UsingShould(arguments[0], "BeEmpty", arguments.Skip(2));
                         }
                         else if (Is(isSymbol, "Not", "Empty"))
                         {
-                            result = RewriteUsingShould(arguments[0], "NotBeEmpty", arguments.Skip(2));
+                            result = rewrite.UsingShould(arguments[0], "NotBeEmpty", arguments.Skip(2));
                         }
                         else if (Is(isSymbol, "Null"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeNull", arguments.Skip(2));
+                            result = rewrite.UsingShould(arguments[0], "BeNull", arguments.Skip(2));
                         }
                         else if (Is(isSymbol, "Not", "Null"))
                         {
-                            result = RewriteUsingShould(arguments[0], "NotBeNull", arguments.Skip(2));
+                            result = rewrite.UsingShould(arguments[0], "NotBeNull", arguments.Skip(2));
                         }
                         else if (Is(isSymbol, "Null", "Or", "Empty") || Is(isSymbol, "Empty", "Or", "Null"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeNullOrEmpty", arguments.Skip(2));
+                            result = rewrite.UsingShould(arguments[0], "BeNullOrEmpty", arguments.Skip(2));
                         }
                         else if (Is(isSymbol, "Not", "Null", "Or", "Empty") || Is(isSymbol, "Not", "Empty", "Or", "Null"))
                         {
-                            result = RewriteUsingShould(arguments[0], "NotBeNullOrEmpty", arguments.Skip(2));
+                            result = rewrite.UsingShould(arguments[0], "NotBeNullOrEmpty", arguments.Skip(2));
                         }
                         else if (Is(hasSymbol, "One", "Items"))
                         {
-                            result = RewriteUsingShould(arguments[0], "HaveCount", ArgumentList(NumericLiteral(1), arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "HaveCount", ArgumentList(NumericLiteral(1), arguments.Skip(2)));
                         }
                         else if (Is(hasSymbol, "Count", "Zero") || Is(hasSymbol, "Length", "Zero"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeEmpty", arguments.Skip(2));
+                            result = rewrite.UsingShould(arguments[0], "BeEmpty", arguments.Skip(2));
                         }
                         else if (IsMethod(out var expected, isSymbol, "EqualTo"))
                         {
-                            result = RewriteUsingShould(arguments[0], "Be", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "Be", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, isSymbol, "Not", "EqualTo"))
                         {
-                            result = RewriteUsingShould(arguments[0], "NotBe", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "NotBe", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, hasSymbol, "Count", "EqualTo") || IsMethod(out expected, hasSymbol, "Length", "EqualTo"))
                         {
-                            result = RewriteUsingShould(arguments[0], "HaveCount", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "HaveCount", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, hasSymbol, "Exactly", "Items"))
                         {
-                            result = RewriteUsingShould(arguments[0], "HaveCount", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "HaveCount", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, containsSymbol, "Substring"))
                         {
-                            result = RewriteUsingShould(arguments[0], "Contain", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "Contain", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, doesSymbol, "Contain"))
                         {
-                            result = RewriteUsingShould(arguments[0], "Contain", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "Contain", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, doesSymbol, "Not", "Contain"))
                         {
-                            result = RewriteUsingShould(arguments[0], "NotContain", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "NotContain", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, doesSymbol, "EndWith"))
                         {
-                            result = RewriteUsingShould(arguments[0], "EndWith", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "EndWith", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, doesSymbol, "Not", "EndWith") || IsMethod(out expected, doesSymbol, "Not", "EndsWith"))
                         {
-                            result = RewriteUsingShould(arguments[0], "NotEndWith", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "NotEndWith", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, doesSymbol, "StartWith"))
                         {
-                            result = RewriteUsingShould(arguments[0], "StartWith", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "StartWith", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, doesSymbol, "Not", "StartWith") || IsMethod(out expected, doesSymbol, "Not", "StartsWith"))
                         {
-                            result = RewriteUsingShould(arguments[0], "NotStartWith", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "NotStartWith", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, isSymbol, "InstanceOf"))
                         {
-                            result = RewriteUsingShould(arguments[0], "BeOfType", ArgumentList(expected, arguments.Skip(2)));
+                            result = rewrite.UsingShould(arguments[0], "BeOfType", ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsGenericMethod(out var instanceOfType, isSymbol, "InstanceOf"))
                         {
                             var exception = (TypeSyntax)generator.TypeExpression(instanceOfType);
-                            result = RewriteUsingShould(arguments[0], "BeOfType", exception, arguments.Skip(2));
+                            result = rewrite.UsingShould(arguments[0], "BeOfType", exception, arguments.Skip(2));
                         }
                         else if (IsMethod(out expected, throwsSymbol, "InstanceOf") && semanticModel.GetOperation(expected, cancellationToken) is ITypeOfOperation typeOfOperation)
                         {
                             var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                             var exception = (TypeSyntax)generator.TypeExpression(typeOfOperation.TypeOperand);
-                            result = RewriteUsingShould(action, "Throw", exception, arguments.Skip(2));
+                            result = rewrite.UsingShould(action, "Throw", exception, arguments.Skip(2));
                         }
                         else if (IsGenericMethod(out var type, throwsSymbol, "InstanceOf"))
                         {
                             var action = InvokeFluentActionsInvoking(compilation, generator, arguments[0].Expression);
                             var exception = (TypeSyntax)generator.TypeExpression(type);
-                            result = RewriteUsingShould(action, "Throw", exception, arguments.Skip(2));
+                            result = rewrite.UsingShould(action, "Throw", exception, arguments.Skip(2));
                         }
                     }
 
@@ -656,102 +657,102 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
         {
             if (methodName is "AreEqualIgnoringCase")
             {
-                result = RewriteUsingShould(arguments[1], "BeEquivalentTo", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "BeEquivalentTo", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "AreNotEqualIgnoringCase")
             {
-                result = RewriteUsingShould(arguments[1], "NotBeEquivalentTo", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotBeEquivalentTo", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "Contains")
             {
-                result = RewriteUsingShould(arguments[1], "Contain", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "Contain", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "DoesNotContain")
             {
-                result = RewriteUsingShould(arguments[1], "NotContain", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotContain", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "DoesNotEndWith")
             {
-                result = RewriteUsingShould(arguments[1], "NotEndWith", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotEndWith", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "DoesNotMatch")
             {
-                result = RewriteUsingShould(arguments[1], "NotMatchRegex", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotMatchRegex", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "DoesNotStartWith")
             {
-                result = RewriteUsingShould(arguments[1], "NotStartWith", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotStartWith", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "EndsWith")
             {
-                result = RewriteUsingShould(arguments[1], "EndWith", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "EndWith", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "IsMatch")
             {
-                result = RewriteUsingShould(arguments[1], "MatchRegex", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "MatchRegex", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "StartsWith")
             {
-                result = RewriteUsingShould(arguments[1], "StartWith", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "StartWith", ArgumentList(arguments[0], arguments.Skip(2)));
             }
         }
         else if (method.ContainingType.Equals(compilation.GetTypeByMetadataName("NUnit.Framework.CollectionAssert"), SymbolEqualityComparer.Default))
         {
             if (methodName is "AllItemsAreInstancesOfType")
             {
-                result = RewriteUsingShould(arguments[0], "AllBeOfType", ArgumentList(arguments[1], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[0], "AllBeOfType", ArgumentList(arguments[1], arguments.Skip(2)));
             }
             else if (methodName is "AllItemsAreNotNull")
             {
-                result = RewriteUsingShould(arguments[0], "NotContainNulls", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "NotContainNulls", arguments.Skip(1));
             }
             else if (methodName is "AllItemsAreUnique")
             {
-                result = RewriteUsingShould(arguments[0], "OnlyHaveUniqueItems", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "OnlyHaveUniqueItems", arguments.Skip(1));
             }
             else if (methodName is "AreEqual" && (method.Parameters.Length <= 2 || !method.Parameters[2].Type.Equals(compilation.GetTypeByMetadataName("System.Collection.IComparer"), SymbolEqualityComparer.Default)))
             {
-                result = RewriteUsingShould(arguments[1], "Equal", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "Equal", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "AreNotEqual" && (method.Parameters.Length <= 2 || !method.Parameters[2].Type.Equals(compilation.GetTypeByMetadataName("System.Collection.IComparer"), SymbolEqualityComparer.Default)))
             {
-                result = RewriteUsingShould(arguments[1], "NotEqual", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotEqual", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "AreEquivalent")
             {
-                result = RewriteUsingShould(arguments[1], "BeEquivalentTo", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "BeEquivalentTo", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "AreNotEquivalent")
             {
-                result = RewriteUsingShould(arguments[1], "NotBeEquivalentTo", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotBeEquivalentTo", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "Contains")
             {
-                result = RewriteUsingShould(arguments[0], "Contain", ArgumentList(arguments[1], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[0], "Contain", ArgumentList(arguments[1], arguments.Skip(2)));
             }
             else if (methodName is "DoesNotContain")
             {
-                result = RewriteUsingShould(arguments[0], "NotContain", ArgumentList(arguments[1], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[0], "NotContain", ArgumentList(arguments[1], arguments.Skip(2)));
             }
             else if (methodName is "IsNotEmpty")
             {
-                result = RewriteUsingShould(arguments[0], "NotBeEmpty", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "NotBeEmpty", arguments.Skip(1));
             }
             else if (methodName is "IsEmpty")
             {
-                result = RewriteUsingShould(arguments[0], "BeEmpty", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "BeEmpty", arguments.Skip(1));
             }
             else if (methodName is "IsSubsetOf")
             {
-                result = RewriteUsingShould(arguments[1], "BeSubsetOf", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "BeSubsetOf", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "IsNotSubsetOf")
             {
-                result = RewriteUsingShould(arguments[1], "NotBeSubsetOf", ArgumentList(arguments[0], arguments.Skip(2)));
+                result = rewrite.UsingShould(arguments[1], "NotBeSubsetOf", ArgumentList(arguments[0], arguments.Skip(2)));
             }
             else if (methodName is "IsOrdered" && (method.Parameters.Length < 2 || !method.Parameters[1].Type.Equals(compilation.GetTypeByMetadataName("System.Collection.IComparer"), SymbolEqualityComparer.Default)))
             {
-                result = RewriteUsingShould(arguments[0], "BeInAscendingOrder", arguments.Skip(1));
+                result = rewrite.UsingShould(arguments[0], "BeInAscendingOrder", arguments.Skip(1));
             }
         }
 
@@ -809,24 +810,25 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
         return list;
     }
 
-    internal static class Rewriter
+    private class Rewriter
     {
-        public static SyntaxNode RewriteUsingShould(ArgumentSyntax subject, string methodName, IEnumerable<ArgumentSyntax> arguments)
+
+        public SyntaxNode UsingShould(ArgumentSyntax subject, string methodName, IEnumerable<ArgumentSyntax> arguments)
         {
-            return RewriteUsingShould(subject.Expression, methodName, genericParameterType: null, arguments);
+            return UsingShould(subject.Expression, methodName, genericParameterType: null, arguments);
         }
 
-        public static SyntaxNode RewriteUsingShould(ExpressionSyntax subject, string methodName, IEnumerable<ArgumentSyntax> arguments)
+        public SyntaxNode UsingShould(ExpressionSyntax subject, string methodName, IEnumerable<ArgumentSyntax> arguments)
         {
-            return RewriteUsingShould(subject, methodName, genericParameterType: null, arguments);
+            return UsingShould(subject, methodName, genericParameterType: null, arguments);
         }
 
-        public static SyntaxNode RewriteUsingShould(ArgumentSyntax subject, string methodName, TypeSyntax genericParameterType, IEnumerable<ArgumentSyntax> arguments)
+        public SyntaxNode UsingShould(ArgumentSyntax subject, string methodName, TypeSyntax genericParameterType, IEnumerable<ArgumentSyntax> arguments)
         {
-            return RewriteUsingShould(subject.Expression, methodName, genericParameterType, arguments);
+            return UsingShould(subject.Expression, methodName, genericParameterType, arguments);
         }
 
-        public static SyntaxNode RewriteUsingShould(ExpressionSyntax subject, string methodName, TypeSyntax genericParameterType, IEnumerable<ArgumentSyntax> arguments)
+        public SyntaxNode UsingShould(ExpressionSyntax subject, string methodName, TypeSyntax genericParameterType, IEnumerable<ArgumentSyntax> arguments)
         {
             var should = InvokeShould(subject);
             should = InvocationExpression(MemberAccessExpression(should, methodName, genericParameterType));
@@ -834,9 +836,9 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
             return should;
         }
 
-        public static SyntaxNode RewriteTrueOrFalse(SeparatedSyntaxList<ArgumentSyntax> originalArguments, string methodName)
+        public SyntaxNode TrueOrFalse(SeparatedSyntaxList<ArgumentSyntax> originalArguments, string methodName)
         {
-            return RewriteUsingShould(originalArguments[0], "Be" + methodName, originalArguments.Skip(1).ToArray());
+            return UsingShould(originalArguments[0], "Be" + methodName, originalArguments.Skip(1).ToArray());
         }
 
         private static InvocationExpressionSyntax InvokeShould(ExpressionSyntax expression)


### PR DESCRIPTION
Support `dynamic`.

Tested end-to-end:
![image](https://user-images.githubusercontent.com/26791344/201895479-644aa6f4-37ad-49b7-aca5-2d41ab6774a8.png)
