### PR TITLE
Fix `Is.EqualTo` for collections

### DIFF
--- a/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
+++ b/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
@@ -616,6 +616,7 @@ class Test
     [InlineData(@"Assert.That("""", Is.Not.EqualTo(""expected""))", @""""".Should().NotBe(""expected"")")]
     [InlineData(@"Assert.That(collection, Is.EqualTo(new int[0]))", @"collection.Should().Equal(new int[0])")]
     [InlineData(@"Assert.That(collection, Is.Not.EqualTo(new int[0]))", @"collection.Should().NotEqual(new int[0])")]
+    [InlineData(@"Assert.That((IEnumerable<int>)collection, Is.EqualTo(new int[0]))", @"((IEnumerable<int>)collection).Should().Equal(new int[0])")]
 
     [InlineData(@"Assert.That(collection, Is.EquivalentTo(new int[0]))", @"collection.Should().BeEquivalentTo(new int[0])")]
     [InlineData(@"Assert.That(collection, Is.Not.EquivalentTo(new int[0]))", @"collection.Should().NotBeEquivalentTo(new int[0])")]
@@ -651,6 +652,7 @@ class Test
     {
         return Assert(
 $$"""
+using System.Collections.Generic;
 using NUnit.Framework;
 
 class Test
@@ -663,6 +665,7 @@ class Test
 }
 """,
 $$"""
+using System.Collections.Generic;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
+++ b/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
@@ -614,6 +614,8 @@ class Test
 
     [InlineData(@"Assert.That("""", Is.EqualTo(""expected""))", @""""".Should().Be(""expected"")")]
     [InlineData(@"Assert.That("""", Is.Not.EqualTo(""expected""))", @""""".Should().NotBe(""expected"")")]
+    [InlineData(@"Assert.That(collection, Is.EqualTo(new int[0]))", @"collection.Should().Equal(new int[0])")]
+    [InlineData(@"Assert.That(collection, Is.Not.EqualTo(new int[0]))", @"collection.Should().NotEqual(new int[0])")]
 
     [InlineData(@"Assert.That(collection, Is.EquivalentTo(new int[0]))", @"collection.Should().BeEquivalentTo(new int[0])")]
     [InlineData(@"Assert.That(collection, Is.Not.EquivalentTo(new int[0]))", @"collection.Should().NotBeEquivalentTo(new int[0])")]

--- a/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
+++ b/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
@@ -53,6 +53,72 @@ class Test
     }
 
     [Fact]
+    public Task EnumerableTest()
+    {
+        return Assert(
+            $$"""
+using System.Collections;
+using NUnit.Framework;
+
+class CustomEnumerable : IEnumerable
+{
+    private readonly IEnumerable m_Collection;
+
+    public CustomEnumerable(IEnumerable collection)
+    {
+        m_Collection = collection;
+    }
+    public IEnumerator GetEnumerator()
+    {
+        foreach (var item in m_Collection)
+        {
+            yield return item;
+        }
+    }
+}
+
+class Test
+{
+    public void MyTest()
+    {
+        var collection = new CustomEnumerable(new int[0]);
+        [||]Assert.That(collection, Is.EqualTo(new int[0]));
+    }
+}
+""",
+            $$"""
+using System.Collections;
+using NUnit.Framework;
+
+class CustomEnumerable : IEnumerable
+{
+    private readonly IEnumerable m_Collection;
+
+    public CustomEnumerable(IEnumerable collection)
+    {
+        m_Collection = collection;
+    }
+    public IEnumerator GetEnumerator()
+    {
+        foreach (var item in m_Collection)
+        {
+            yield return item;
+        }
+    }
+}
+
+class Test
+{
+    public void MyTest()
+    {
+        var collection = new CustomEnumerable(new int[0]);
+        Assert.That(collection, Is.EqualTo(new int[0]));
+    }
+}
+""");
+    }
+
+    [Fact]
     public Task Assert_Dynamic()
     {
         return Assert(

--- a/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
@@ -589,7 +589,11 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
                         var argumentTypeSymbol = semanticModel.GetTypeInfo(argumentSyntax.Expression, cancellationToken).Type;
                         if (argumentTypeSymbol == null || argumentTypeSymbol.SpecialType == SpecialType.System_String)
                             return false;
-                        return argumentTypeSymbol.OriginalDefinition.AllInterfaces.Any(i => i.SpecialType == SpecialType.System_Collections_IEnumerable);
+                        return argumentTypeSymbol.OriginalDefinition.TypeKind == TypeKind.Array
+                            || argumentTypeSymbol.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T
+                            || argumentTypeSymbol.OriginalDefinition.AllInterfaces.Any(i => 
+                                i.TypeKind == TypeKind.Array ||
+                                i.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T);
                     }
 
                     bool Is(ITypeSymbol root, params string[] memberNames)

--- a/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
@@ -590,7 +590,7 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
                         var argumentTypeSymbol = semanticModel.GetTypeInfo(argumentSyntax.Expression, cancellationToken).Type;
                         if (iEnumerableSymbol == null || argumentTypeSymbol == null || argumentTypeSymbol.SpecialType == SpecialType.System_String)
                             return false;
-                        return argumentTypeSymbol.AllInterfaces.Any(i => iEnumerableSymbol.Equals(i, SymbolEqualityComparer.Default));
+                        return argumentTypeSymbol.OriginalDefinition.AllInterfaces.Any(i => iEnumerableSymbol.OriginalDefinition.Equals(i, SymbolEqualityComparer.Default));
                     }
 
                     bool Is(ITypeSymbol root, params string[] memberNames)

--- a/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
@@ -587,8 +587,8 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
 
                     bool IsCollection(ArgumentSyntax argumentSyntax)
                     {
-                        var argumentTypeSymbol = semanticModel.GetOperation(argumentSyntax.Expression, cancellationToken)?.Type;
-                        if (iEnumerableSymbol == null || argumentTypeSymbol == null || argumentTypeSymbol.Equals(stringSymbol, SymbolEqualityComparer.Default))
+                        var argumentTypeSymbol = semanticModel.GetTypeInfo(argumentSyntax.Expression, cancellationToken).Type;
+                        if (iEnumerableSymbol == null || argumentTypeSymbol == null || argumentTypeSymbol.SpecialType == SpecialType.System_String)
                             return false;
                         return argumentTypeSymbol.AllInterfaces.Any(i => iEnumerableSymbol.Equals(i, SymbolEqualityComparer.Default));
                     }

--- a/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
@@ -164,7 +164,6 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
         var compilation = editor.SemanticModel.Compilation;
 
         var stringSymbol = compilation.GetTypeByMetadataName("System.String");
-        var iEnumerableSymbol = compilation.GetTypeByMetadataName("System.Collections.IEnumerable");
         var exceptionSymbol = compilation.GetTypeByMetadataName("System.Exception");
         var typeSymbol = compilation.GetTypeByMetadataName("System.Type");
         var resolveConstraintSymbol = compilation.GetTypeByMetadataName("NUnit.Framework.Constraints.IResolveConstraint");
@@ -588,9 +587,9 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
                     bool IsCollection(ArgumentSyntax argumentSyntax)
                     {
                         var argumentTypeSymbol = semanticModel.GetTypeInfo(argumentSyntax.Expression, cancellationToken).Type;
-                        if (iEnumerableSymbol == null || argumentTypeSymbol == null || argumentTypeSymbol.SpecialType == SpecialType.System_String)
+                        if (argumentTypeSymbol == null || argumentTypeSymbol.SpecialType == SpecialType.System_String)
                             return false;
-                        return argumentTypeSymbol.OriginalDefinition.AllInterfaces.Any(i => iEnumerableSymbol.OriginalDefinition.Equals(i, SymbolEqualityComparer.Default));
+                        return argumentTypeSymbol.OriginalDefinition.AllInterfaces.Any(i => i.SpecialType == SpecialType.System_Collections_IEnumerable);
                     }
 
                     bool Is(ITypeSymbol root, params string[] memberNames)


### PR DESCRIPTION
Fix `Is.EqualTo` for collections.
It should be translated to `Should().Equal()` rather than `Should().Be()`.

## Note

I had an NRE, but wasn't able to figure out where was it coming from, so `IsCollection` is now as defensive as possible - but at least it works fine on a big solution.
```
System.NullReferenceException : Object reference not set to an instance of an object.
   at Meziantou.FluentAssertionsAnalyzers.NunitAssertAnalyzerCodeFixProvider.<>c__DisplayClass5_0.<Rewrite>g__IsCollection|0(ArgumentSyntax argumentSyntax)
```