### PR TITLE
Fix Has.Length for strings

### DIFF
--- a/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
+++ b/Meziantou.FluentAssertionsAnalyzers.Tests/NUnitToFluentAssertionsAnalyzerUnitTests.cs
@@ -609,6 +609,7 @@ class Test
     [InlineData(@"Assert.That(collection, Has.Length.Zero)", @"collection.Should().BeEmpty()")]
     [InlineData(@"Assert.That(collection, Has.Count.EqualTo(2))", @"collection.Should().HaveCount(2)")]
     [InlineData(@"Assert.That(collection, Has.Length.EqualTo(2))", @"collection.Should().HaveCount(2)")]
+    [InlineData(@"Assert.That(""aa"", Has.Length.EqualTo(2))", @"""aa"".Should().HaveLength(2)")]
 
     [InlineData(@"Assert.That("""", Is.EqualTo(""expected""))", @""""".Should().Be(""expected"")")]
     [InlineData(@"Assert.That("""", Is.Not.EqualTo(""expected""))", @""""".Should().NotBe(""expected"")")]

--- a/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
@@ -495,7 +495,8 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
                         else if (IsMethod(out expected, hasSymbol, "Count", "EqualTo") || IsMethod(out expected, hasSymbol, "Length", "EqualTo"))
                         {
                             var argumentTypeSymbol = semanticModel.GetTypeInfo(arguments[0].Expression, cancellationToken).Type;
-                            var replacementMethodName = argumentTypeSymbol.SpecialType == SpecialType.System_String ? "HaveLength" : "HaveCount";
+                            var replacementMethodName = argumentTypeSymbol?.SpecialType == SpecialType.System_String ? "HaveLength" : "HaveCount";
+
                             result = rewrite.UsingShould(arguments[0], replacementMethodName, ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, hasSymbol, "Exactly", "Items"))

--- a/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
+++ b/Meziantou.FluentAssertionsAnalyzers/NunitAssertAnalyzerCodeFixProvider.cs
@@ -494,7 +494,9 @@ public sealed class NunitAssertAnalyzerCodeFixProvider : CodeFixProvider
                         }
                         else if (IsMethod(out expected, hasSymbol, "Count", "EqualTo") || IsMethod(out expected, hasSymbol, "Length", "EqualTo"))
                         {
-                            result = rewrite.UsingShould(arguments[0], "HaveCount", ArgumentList(expected, arguments.Skip(2)));
+                            var argumentTypeSymbol = semanticModel.GetTypeInfo(arguments[0].Expression, cancellationToken).Type;
+                            var replacementMethodName = argumentTypeSymbol.SpecialType == SpecialType.System_String ? "HaveLength" : "HaveCount";
+                            result = rewrite.UsingShould(arguments[0], replacementMethodName, ArgumentList(expected, arguments.Skip(2)));
                         }
                         else if (IsMethod(out expected, hasSymbol, "Exactly", "Items"))
                         {


### PR DESCRIPTION
Fix `Has.Length` for strings: it should be migrated to `HaveLength` as opposed to `HaveCount` - see https://fluentassertions.com/strings/